### PR TITLE
feat: Add images sizes

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -46,6 +46,7 @@ export default async function AllProductsPage() {
                     src={product.imageUrl}
                     alt={product.title}
                     fill={true}
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                     className="object-contain p-2"
                     data-ai-hint={getAiHint(product.title)}
                   />

--- a/src/components/store-profile.tsx
+++ b/src/components/store-profile.tsx
@@ -10,6 +10,8 @@ export default function StoreProfile() {
         <div className="relative h-48 w-full bg-muted">
           <Image
             src="/assets/images/banner_store.png"
+            priority={false}
+            loading="lazy"
             alt="Store banner"
             fill
             className="object-cover rounded-t-lg"
@@ -21,6 +23,8 @@ export default function StoreProfile() {
             <div className="relative h-32 w-32 rounded-full border-4 border-card bg-card">
               <Image
                 src="/assets/images/profile_store.png"
+                priority={false}
+                loading="lazy"
                 alt="Terry1921 Store profile image"
                 fill
                 className="object-cover rounded-full"


### PR DESCRIPTION
This pull request includes improvements to image rendering in the `AllProductsPage` and `StoreProfile` components. The changes enhance responsiveness and optimize image loading behavior.

### Image responsiveness and optimization:

* [`src/app/products/page.tsx`](diffhunk://#diff-c4795581d93b787b04d3b802a7d5093b6300f4487fb07a5426cc9df5aa70a20eR49): Added the `sizes` attribute to the `Image` component in `AllProductsPage` to improve responsiveness based on device width.
* [`src/components/store-profile.tsx`](diffhunk://#diff-2364797b667a72af2aae2c47097f5ba9e5edf13cda230a923c00cea80e3b9d2dR13-R14): Updated the `Image` components in `StoreProfile` to include `priority={false}` and `loading="lazy"`, optimizing the loading behavior for non-critical images. [[1]](diffhunk://#diff-2364797b667a72af2aae2c47097f5ba9e5edf13cda230a923c00cea80e3b9d2dR13-R14) [[2]](diffhunk://#diff-2364797b667a72af2aae2c47097f5ba9e5edf13cda230a923c00cea80e3b9d2dR26-R27)